### PR TITLE
Fix asset URL builder

### DIFF
--- a/filemequietly/utils/get_assets_path.py
+++ b/filemequietly/utils/get_assets_path.py
@@ -13,9 +13,9 @@ def get_assets_path ():
 def get_asset_in_github_link (*paths):
     """Pass path names to get a link to the assets located in GitHub in FileMeQuietly repo."""
 
-    l = "https://raw.githubusercontent.com/SKbarbon/filemequietly/main/filemequietly/assets/"
-    
+    base_url = "https://raw.githubusercontent.com/SKbarbon/filemequietly/main/filemequietly/assets"
+
     for p in paths:
-        l = f"{l}{p}/"
-    
-    return l
+        base_url = f"{base_url}/{p}"
+
+    return base_url


### PR DESCRIPTION
## Summary
- correct GitHub asset URL generation

## Testing
- `python -m compileall -q filemequietly`

------
https://chatgpt.com/codex/tasks/task_e_6844174fad448333abae3fb8aa83c607